### PR TITLE
Show canonical if noindex

### DIFF
--- a/Classes/EventListener/ModifyUrlForCanonicalTagEventListener.php
+++ b/Classes/EventListener/ModifyUrlForCanonicalTagEventListener.php
@@ -46,7 +46,7 @@ class ModifyUrlForCanonicalTagEventListener
         }
 
         $row = FetchUtility::getRow($newsId);
-        if (!($row['robots_index'] ?? false)) {
+        if (!($row['robots_index'] ?? false) && !($row['canonical_link'] ?? false)) {
             return;
         }
 


### PR DESCRIPTION
As mentioned here it would be useful to show canonical even if noindex is aktive:
https://github.com/georgringer/news_seo/issues/5#issuecomment-1365279205

https://www.searchenginejournal.com/when-to-use-rel-canonical-or-noindex-or-both/427522/