### PR TITLE
Add version information in TCA Overrides

### DIFF
--- a/Configuration/TCA/Overrides/tx_news_domain_model_news.php
+++ b/Configuration/TCA/Overrides/tx_news_domain_model_news.php
@@ -1,5 +1,5 @@
 <?php
-
+$versionInformation = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(\TYPO3\CMS\Core\Information\Typo3Version::class);
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addTCAcolumns(
     'tx_news_domain_model_news',
     [
@@ -9,11 +9,6 @@
             'label' => 'LLL:EXT:news_seo/Resources/Private/Language/locallang.xlf:tx_news_domain_model_news.robots_index',
             'config' => [
                 'type' => 'check',
-                'items' => [
-                    [
-                        0 => '',
-                    ],
-                ],
                 'default' => 1,
             ],
         ],
@@ -33,18 +28,22 @@
             'config' => [
                 'type' => 'select',
                 'renderType' => 'selectSingle',
-                'items' => [
+                'items' => $versionInformation->getMajorVersion() < 12 ? [
+                    ['LLL:EXT:news_seo/Resources/Private/Language/locallang.xlf:tx_news_domain_model_news.max_image_preview.none', 0,],
+                    ['LLL:EXT:news_seo/Resources/Private/Language/locallang.xlf:tx_news_domain_model_news.max_image_preview.standard', 1,],
+                    ['LLL:EXT:news_seo/Resources/Private/Language/locallang.xlf:tx_news_domain_model_news.max_image_preview.large', 2,],
+                ] : [
                     [
-                        'LLL:EXT:news_seo/Resources/Private/Language/locallang.xlf:tx_news_domain_model_news.max_image_preview.none',
-                        0,
+                        'label' => 'LLL:EXT:news_seo/Resources/Private/Language/locallang.xlf:tx_news_domain_model_news.max_image_preview.none',
+                        'value' => 0,
                     ],
                     [
-                        'LLL:EXT:news_seo/Resources/Private/Language/locallang.xlf:tx_news_domain_model_news.max_image_preview.standard',
-                        1,
+                        'label' => 'LLL:EXT:news_seo/Resources/Private/Language/locallang.xlf:tx_news_domain_model_news.max_image_preview.standard',
+                        'value' => 1,
                     ],
                     [
-                        'LLL:EXT:news_seo/Resources/Private/Language/locallang.xlf:tx_news_domain_model_news.max_image_preview.large',
-                        2,
+                        'label' => 'LLL:EXT:news_seo/Resources/Private/Language/locallang.xlf:tx_news_domain_model_news.max_image_preview.large',
+                        'value' => 2,
                     ],
                 ],
                 'default' => 1,
@@ -53,7 +52,7 @@
         'canonical_link' => [
             'exclude' => true,
             'label' => 'LLL:EXT:news_seo/Resources/Private/Language/locallang.xlf:tx_news_domain_model_news.canonical_link',
-            'config' => [
+            'config' => $versionInformation->getMajorVersion() < 12 ? [
                 'type' => 'input',
                 'renderType' => 'inputLink',
                 'size' => 30,
@@ -67,7 +66,16 @@
                         ],
                     ],
                 ],
-            ]
+            ] : [
+                'type' => 'link',
+                'size' => 30,
+                //allowed types tx_news: linkhandler must be set (typically called "tx_news" TCEMAIN.linkHandler.tx_news)
+                'allowedTypes' => ['page', 'url', 'tx_news'],
+                'appearance' => [
+                    'browserTitle' => 'LLL:EXT:news_seo/Resources/Private/Language/locallang.xlf:tx_news_domain_model_news.canonical_link',
+                    'allowedOptions' => ['params',],
+                ],
+            ],
         ],
     ]
 );


### PR DESCRIPTION
There are some fields that need a new/ different config in TYPO3 12

PR adds a version information split and depending on the version adds the correct TCA config.
Similar to EXT:news tx_news_domain_model_news