### PR TITLE
Fixed issue where the controller assigned a default news object to the detail view instead of a News model object.

### DIFF
--- a/Classes/EventListener/NewsDetailActionEventListener.php
+++ b/Classes/EventListener/NewsDetailActionEventListener.php
@@ -22,7 +22,7 @@ class NewsDetailActionEventListener
     {
         /** @var News $news */
         $news = $event->getAssignedValues()['newsItem'];
-        if ($news) {
+        if (is_a($news, News::class) && $news) {
             $robots = [
                 $news->isRobotsIndex() ? 'index' : 'noindex',
                 $news->isRobotsFollow() ? 'follow' : 'nofollow',


### PR DESCRIPTION
In some cases, the controller assigns a NewsDefault model object, which lacks the defined properties, causing issues. A small check is added to resolve this problem.