### PR TITLE
[bugfix] Remove redundant condition...

### DIFF
--- a/Classes/EventListener/ModifyHrefLangEventListener.php
+++ b/Classes/EventListener/ModifyHrefLangEventListener.php
@@ -44,14 +44,11 @@ class ModifyHrefLangEventListener
 
     public function __invoke(ModifyHrefLangTagsEvent $event): void
     {
-        if ($this->getTypoScriptFrontendController()->page['no_index']) {
-            return;
-        }
-
-        $newsAvailabilityChecker = GeneralUtility::makeInstance(NewsAvailability::class);
         $newsId = $this->getNewsIdFromRequest();
         if ($newsId > 0) {
             if (FetchUtility::isNoIndex($newsId)) {
+                //remove all previously generated page hreflangs if news article should not be indexed but page has no_index=0
+                $event->setHrefLangs([]);
                 return;
             }
             if (GeneralUtility::makeInstance(Typo3Version::class)->getMajorVersion() > 10) {
@@ -97,6 +94,7 @@ class ModifyHrefLangEventListener
                 }
 
                 try {
+                    $newsAvailabilityChecker = GeneralUtility::makeInstance(NewsAvailability::class);
                     $check = $newsAvailabilityChecker->check($language['languageId']);
 
                     if (!$check) {

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -8,7 +8,7 @@ $EM_CONF[$_EXTKEY] = [
     'author_email' => 'mail@ringer.it',
     'state' => 'stable',
     'clearCacheOnLoad' => true,
-    'version' => '2.2.0',
+    'version' => '2.2.1',
     'constraints' =>
         [
             'depends' => [


### PR DESCRIPTION
Removes the redundant condition, that prevents the hreflang generation for news-articles on pages with no_index=1
Removes all hreflang tags that were generated for the page (if a news article with robots_index=0 is requested)
Move the $newsAvailablity object to the place where it's actually needed
see #26 
