### PR TITLE
[BUGFIX] Render max-image-preview only once on noindex articles

### DIFF
--- a/Classes/EventListener/NewsDetailActionEventListener.php
+++ b/Classes/EventListener/NewsDetailActionEventListener.php
@@ -28,9 +28,6 @@ class NewsDetailActionEventListener
                 $news->isRobotsFollow() ? 'follow' : 'nofollow',
                 $news->getMaxImagePreviewString(),
             ];
-            if (!$news->isRobotsIndex()) {
-                $robots[] = $news->getMaxImagePreviewString();
-            }
 
             $robots = array_filter($robots);
             $metaTagManagerRegistry = GeneralUtility::makeInstance(MetaTagManagerRegistry::class);

--- a/Tests/Functional/EventListener/NewsDetailActionEventListenerTest.php
+++ b/Tests/Functional/EventListener/NewsDetailActionEventListenerTest.php
@@ -57,6 +57,11 @@ class NewsDetailActionEventListenerTest extends FunctionalTestCase
             'indexed with a large preview' => [true, true, 2, 'index,follow,max-image-preview:large'],
             'indexed but not followed' => [true, false, 0, 'index,nofollow'],
             'excluded from the index' => [false, false, 0, 'noindex,nofollow'],
+            // The image preview directive is independent of indexing, so it
+            // has to survive a noindex - exactly once. See issue #41.
+            'excluded with a standard preview' => [false, false, 1, 'noindex,nofollow,max-image-preview:standard'],
+            'excluded with a large preview' => [false, false, 2, 'noindex,nofollow,max-image-preview:large'],
+            'excluded but followed, with a preview' => [false, true, 2, 'noindex,follow,max-image-preview:large'],
         ];
     }
 

--- a/Tests/Functional/Frontend/Fixtures/news.csv
+++ b/Tests/Functional/Frontend/Fixtures/news.csv
@@ -8,6 +8,7 @@ tx_news_domain_model_news,,,,,,,,,,,,
 ,10,2,0,"Article translated into every language","Teaser ten","Bodytext ten",1,1,0,"",0,0
 ,11,2,0,"Article translated into German only","Teaser eleven","Bodytext eleven",1,1,0,"",0,0
 ,12,2,0,"Translated article excluded from the index","Teaser twelve","Bodytext twelve",0,0,0,"",0,0
+,13,2,0,"Excluded from the index but asking for a large preview","Teaser thirteen","Bodytext thirteen",0,0,2,"",0,0
 ,110,2,0,"Artikel in allen Sprachen","Teaser zehn","Bodytext zehn",1,1,0,"",1,10
 ,120,2,0,"Article traduit dans toutes les langues","Teaser dix","Bodytext dix",1,1,0,"",2,10
 ,111,2,0,"Artikel nur auf Deutsch","Teaser elf","Bodytext elf",1,1,0,"",1,11

--- a/Tests/Functional/Frontend/RobotsMetaTagTest.php
+++ b/Tests/Functional/Frontend/RobotsMetaTagTest.php
@@ -32,6 +32,10 @@ class RobotsMetaTagTest extends AbstractFrontendTestCase
             'excluded from the index' => [2, 'noindex,nofollow'],
             'large image preview' => [3, 'index,follow,max-image-preview:large'],
             'indexed, not followed, standard preview' => [4, 'index,nofollow,max-image-preview:standard'],
+            // max-image-preview says how an image may be shown, not whether
+            // the page is indexed, so it has to come through on a noindex
+            // article too - and only once. See issue #41.
+            'excluded from the index, large preview' => [13, 'noindex,nofollow,max-image-preview:large'],
         ];
     }
 


### PR DESCRIPTION
Fixes #41

## Problem

`getMaxImagePreviewString()` is already the third element of the robots array, so the extra append for articles with `robots_index = 0` did nothing but duplicate it:

```php
$robots = [
    $news->isRobotsIndex() ? 'index' : 'noindex',
    $news->isRobotsFollow() ? 'follow' : 'nofollow',
    $news->getMaxImagePreviewString(),
];
if (!$news->isRobotsIndex()) {
    $robots[] = $news->getMaxImagePreviewString();
}
```

`array_filter()` drops empty strings but does not deduplicate. That is why the default `max_image_preview = 0` hides the problem — both entries are empty and get filtered away — while any other value on a noindex article renders

```html
<meta name="robots" content="noindex,nofollow,max-image-preview:large,max-image-preview:large">
```

## Fix

Drop the `if` block. Whether a noindex article should carry the directive at all is a separate question and is deliberately left as it is.

## Tests

The noindex plus preview combination was the one case left out when the test suite was written, so that the broken output would not be pinned. It is now covered, and both additions fail before the fix:

* `Tests/Functional/EventListener/NewsDetailActionEventListenerTest` — three combinations of `noindex` with a standard and a large preview, plus `noindex,follow` with a preview.
* `Tests/Functional/Frontend/RobotsMetaTagTest` — a fixture article with `robots_index = 0` and `max_image_preview = 2`, asserted through the rendered detail page.

## Verification

98 functional and 11 unit tests green on

* TYPO3 14.3.6 with EXT:news 14.1.1 on PHP 8.4 (sqlite, postgres)
* TYPO3 13.4.29 with EXT:news 13.0.0 on PHP 8.2 (sqlite, postgres, mariadb/mysqli)

plus `lint`, `cgl -n` and `fractor -n`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)