### PR TITLE
[BUGFIX] Return an empty array from getRow() for an unknown record

### DIFF
--- a/Classes/Utility/FetchUtility.php
+++ b/Classes/Utility/FetchUtility.php
@@ -39,12 +39,12 @@ class FetchUtility
     {
         $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)
             ->getQueryBuilderForTable('tx_news_domain_model_news');
-        return (array)$queryBuilder->select('uid', 'title', 'sys_language_uid', 'robots_index', 'canonical_link')
+        return $queryBuilder->select('uid', 'title', 'sys_language_uid', 'robots_index', 'canonical_link')
             ->from('tx_news_domain_model_news')
             ->where(
                 $queryBuilder->expr()->eq('uid', $queryBuilder->createNamedParameter($newsId, Connection::PARAM_INT))
             )
             ->executeQuery()
-            ->fetchAssociative();
+            ->fetchAssociative() ?: [];
     }
 }

--- a/Tests/Functional/Utility/FetchUtilityTest.php
+++ b/Tests/Functional/Utility/FetchUtilityTest.php
@@ -70,10 +70,19 @@ class FetchUtilityTest extends FunctionalTestCase
     }
 
     /**
-     * An unknown uid makes fetchAssociative() return false, which the (array)
-     * cast in getRow() turns into [0 => false] rather than []. Both listeners
-     * cope because they read the columns with "?? false", and that is what is
-     * pinned here: an unknown record yields no usable SEO data.
+     * An unknown uid makes fetchAssociative() return false. The method
+     * promises an array, and an empty one is the only honest answer - callers
+     * have to be able to use empty() or count() on the result. See issue #43.
+     */
+    #[Test]
+    public function getRowReturnsAnEmptyArrayForAnUnknownRecord(): void
+    {
+        self::assertSame([], FetchUtility::getRow(99));
+    }
+
+    /**
+     * The two listeners read the columns defensively, so the shape of the
+     * result must not offer anything that looks like SEO data either.
      */
     #[Test]
     public function getRowCarriesNoSeoDataForAnUnknownRecord(): void


### PR DESCRIPTION
Fixes #43

## Problem

`fetchAssociative()` returns `false` when nothing matches, and `(array)false` is `[0 => false]`, not `[]`. `FetchUtility::getRow()` therefore handed back a non-empty array whose only element is a boolean, so every `empty()` or `count()` check on the result takes the wrong branch.

Both current callers survive this because they read the columns defensively:

```php
if (!($row['robots_index'] ?? false) && !($row['canonical_link'] ?? false)) {
    return;
}
```

So this is a trap for the next caller rather than an active bug.

## Fix

```diff
-        return (array)$queryBuilder->select(...)
+        return $queryBuilder->select(...)
             ...
-            ->fetchAssociative();
+            ->fetchAssociative() ?: [];
```

## Tests

`Tests/Functional/Utility/FetchUtilityTest::getRowReturnsAnEmptyArrayForAnUnknownRecord()` pins the contract and fails before the fix with exactly the reported value:

```
-Array &0 []
+Array &0 [
+    0 => false,
+]
```

The existing `getRowCarriesNoSeoDataForAnUnknownRecord()` stays: it asserts what the two listeners actually rely on, independently of the return shape. Its docblock no longer describes the cast artefact as expected behaviour.

## Verification

99 functional and 11 unit tests green on

* TYPO3 14.3.6 with EXT:news 14.1.1 on PHP 8.4 (sqlite, postgres)
* TYPO3 13.4.29 with EXT:news 13.0.0 on PHP 8.2 (sqlite, postgres, mariadb/mysqli)

plus `lint`, `cgl -n` and `fractor -n`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)